### PR TITLE
Optimizing $.type()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -180,10 +180,14 @@ $.extend = function(to, from) {
 };
 
 $.type = (function() {
-  var oString = Object.prototype.toString,
-      re = /^\[object\s(.*)\]$/,
-      type = function(e) { return oString.call(e).match(re)[1].toLowerCase(); };
-  
+  var isArray = Array.isArray,
+      type = function(e) {
+        if (Array.isArray(e)) return 'array';
+        var t = typeof e;
+        if (t !== 'object') return t;
+        return e.constructor.name.toLowerCase();
+      };
+
   return function(elem) {
     var elemType = type(elem);
     if (elemType != 'object') {


### PR DESCRIPTION
Hi,

I tried profiling scene.render() with 400 cubes. It looks like 20% of the time is spent inside $.type()
This commit reduces it to 2%.

Not exhaustively tested, but it does pass the unit tests ;-)

Nice work on PhiloGL!
--Will
