### PR TITLE
Make distTo calculate the correct sqrt

### DIFF
--- a/src/math.js
+++ b/src/math.js
@@ -148,8 +148,8 @@
           dy = dest.y - vec.y,
           dz = dest.z - vec.z;
       
-      return sqrt(dx * dx,
-                  dy * dy,
+      return sqrt(dx * dx +
+                  dy * dy +
                   dz * dz);
     },
 


### PR DESCRIPTION
Fixes a bug in distTo where only the x distance was being calculated.
