### PR TITLE
Scoping Functions and Adding Multiple GL Context Support

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -4,7 +4,8 @@
 (function () {
   //Define some locals
   var Vec3 = PhiloGL.Vec3,
-      Mat4 = PhiloGL.Mat4;
+      Mat4 = PhiloGL.Mat4,
+      $ = PhiloGL.$;
 
   //Camera class
   var Camera = function(fov, aspect, near, far, opt) {

--- a/src/core.js
+++ b/src/core.js
@@ -80,7 +80,7 @@ this.PhiloGL = null;
               count--;
               if (count === 0 && !error) {
                 loadProgramDeps(gl, programLength == 1? p : programs, function(app) {
-                  opt.onLoad(app);
+                  opt.onLoad(PhiloGL.app);
                 });
               }
             },
@@ -122,14 +122,14 @@ this.PhiloGL = null;
       //get Scene
       var scene = new PhiloGL.Scene(program, camera, optScene);
 
-      //make app instance global to all framework
-      app = new PhiloGL.WebGL.Application({
+      PhiloGL.app = new PhiloGL.WebGL.Application({
         gl: gl,
         canvas: canvas,
         program: program,
         scene: scene,
         camera: camera
       });
+      var app = PhiloGL.app;
 
       //Use program
       if (program.$$family == 'program') {
@@ -159,22 +159,25 @@ this.PhiloGL = null;
 })();
 
 
-//Unpacks the submodules to the global space.
-PhiloGL.unpack = function(branch) {
-  branch = branch || globalContext;
-  ['Vec3', 'Mat4', 'Quat', 'Camera', 'Program', 'WebGL', 'O3D',
-   'Scene', 'Shaders', 'IO', 'Events', 'WorkerGroup', 'Fx', 'Media'].forEach(function(module) {
-      branch[module] = PhiloGL[module];
-  });
-  branch.gl = gl;
-  branch.Utils = PhiloGL.$;
-};
+(function() {
+  globalContext = this;
+  //Unpacks the submodules to the global space.
+  PhiloGL.unpack = function(branch) {
+    branch = branch || globalContext;
+    ['Vec3', 'Mat4', 'Quat', 'Camera', 'Program', 'WebGL', 'O3D',
+     'Scene', 'Shaders', 'IO', 'Events', 'WorkerGroup', 'Fx', 'Media'].forEach(function(module) {
+        branch[module] = PhiloGL[module];
+    });
+    branch.gl = gl;
+    branch.Utils = PhiloGL.$;
+  };
+});
 
 //Version
 PhiloGL.version = '1.5.2';
 
 //Holds the 3D context, holds the application
-var gl, app, globalContext = this;
+var gl
 
 //Utility functions
 (function() {

--- a/src/core.js
+++ b/src/core.js
@@ -51,15 +51,20 @@ this.PhiloGL = null;
         optEvents = opt.events,
         optTextures = opt.textures,
         optProgram = $.splat(opt.program),
-        optScene = opt.scene;
+        optScene = opt.scene
+        program = null;
 
-    //get Context global to all framework
-    gl = PhiloGL.WebGL.getContext(canvasId, optContext);
+    //Get the 3D context, holds the application
+    var gl = PhiloGL.WebGL.getContext(canvasId, optContext);
+    PhiloGL.glConstants = gl;
 
     if (!gl) {
         opt.onError("The WebGL context couldn't been initialized");
         return null;
     }
+
+    //make app instance
+    var app = new PhiloGL.WebGL.Application({gl: gl});
 
     //get Program
     var popt = {
@@ -80,7 +85,7 @@ this.PhiloGL = null;
               count--;
               if (count === 0 && !error) {
                 loadProgramDeps(gl, programLength == 1? p : programs, function(app) {
-                  opt.onLoad(PhiloGL.app);
+                  opt.onLoad(app);
                 });
               }
             },
@@ -94,13 +99,15 @@ this.PhiloGL = null;
 
     optProgram.forEach(function(optProgram, i) {
       var pfrom = optProgram.from, program;
+      optProgram.gl = gl;
+      optProgram.app = app;
       for (var p in popt) {
         if (pfrom == p) {
-          try {
+          //try {
             program = PhiloGL.Program[popt[p]]($.extend(programCallback, optProgram));
-          } catch(e) {
-            programCallback.onError(e);
-          }
+          //} catch(e) {
+          //  programCallback.onError(e);
+          //}
           break;
         }
       }
@@ -122,14 +129,10 @@ this.PhiloGL = null;
       //get Scene
       var scene = new PhiloGL.Scene(program, camera, optScene);
 
-      PhiloGL.app = new PhiloGL.WebGL.Application({
-        gl: gl,
-        canvas: canvas,
-        program: program,
-        scene: scene,
-        camera: camera
-      });
-      var app = PhiloGL.app;
+      app.program = program;
+      app.canvas = canvas;
+      app.scene = scene;
+      app.camera = camera;
 
       //Use program
       if (program.$$family == 'program') {
@@ -149,7 +152,7 @@ this.PhiloGL = null;
           onComplete: function() {
             callback(app);
           }
-        }));
+        }), app);
       } else {
         callback(app);
       }
@@ -175,9 +178,6 @@ this.PhiloGL = null;
 
 //Version
 PhiloGL.version = '1.5.2';
-
-//Holds the 3D context, holds the application
-var gl
 
 //Utility functions
 (function() {

--- a/src/core.js
+++ b/src/core.js
@@ -8,6 +8,7 @@ this.PhiloGL = null;
 //with a gl context, a camera, a program, a scene, and an event system.
 (function () {
   PhiloGL = function(canvasId, opt) {
+    var $ = PhiloGL.$;
     opt = $.merge({
       context: {
         /*
@@ -166,7 +167,7 @@ PhiloGL.unpack = function(branch) {
       branch[module] = PhiloGL[module];
   });
   branch.gl = gl;
-  branch.Utils = $;
+  branch.Utils = PhiloGL.$;
 };
 
 //Version
@@ -176,47 +177,48 @@ PhiloGL.version = '1.5.2';
 var gl, app, globalContext = this;
 
 //Utility functions
-function $(d) {
-  return document.getElementById(d);
-}
-
-$.empty = function() {};
-
-$.time = Date.now;
-
-$.uid = (function() {
-  var t = $.time();
-
-  return function() {
-    return t++;
-  };
-})();
-
-$.extend = function(to, from) {
-  for (var p in from) {
-    to[p] = from[p];
-  }
-  return to;
-};
-
-$.type = (function() {
-  var oString = Object.prototype.toString,
-      type = function(e) {
-        var t = oString.call(e);
-        return t.substr(8, t.length - 9).toLowerCase();
-      };
-
-  return function(elem) {
-    var elemType = type(elem);
-    if (elemType != 'object') {
-      return elemType;
-    }
-    if (elem.$$family) return elem.$$family;
-    return (elem && elem.nodeName && elem.nodeType == 1) ? 'element' : elemType;
-  };
-})();
-
 (function() {
+  PhiloGL.$ = function (d) {
+    return document.getElementById(d);
+  }
+  var $ = PhiloGL.$;
+
+  $.empty = function() {};
+
+  $.time = Date.now;
+
+  $.uid = (function() {
+    var t = $.time();
+
+    return function() {
+      return t++;
+    };
+  })();
+
+  $.extend = function(to, from) {
+    for (var p in from) {
+      to[p] = from[p];
+    }
+    return to;
+  };
+
+  $.type = (function() {
+    var oString = Object.prototype.toString,
+        type = function(e) {
+          var t = oString.call(e);
+          return t.substr(8, t.length - 9).toLowerCase();
+        };
+
+    return function(elem) {
+      var elemType = type(elem);
+      if (elemType != 'object') {
+        return elemType;
+      }
+      if (elem.$$family) return elem.$$family;
+      return (elem && elem.nodeName && elem.nodeType == 1) ? 'element' : elemType;
+    };
+  })();
+
   function detach(elem) {
     var type = $.type(elem), ans;
     if (type == 'object') {
@@ -252,12 +254,12 @@ $.type = (function() {
     }
     return mix;
   };
-})();
 
-$.splat = (function() {
-  var isArray = Array.isArray;
-  return function(a) {
-    return isArray(a) && a || [a];
-  };
-})();
+  $.splat = (function() {
+    var isArray = Array.isArray;
+    return function(a) {
+      return isArray(a) && a || [a];
+    };
+  })();
 
+})();

--- a/src/event.js
+++ b/src/event.js
@@ -2,6 +2,7 @@
 //Handle keyboard/mouse/touch events in the Canvas
 
 (function() {
+  var $ = PhiloGL.$;
   
   //returns an O3D object or false otherwise.
   function toO3D(n) {

--- a/src/fx.js
+++ b/src/fx.js
@@ -1,4 +1,6 @@
 (function() {
+  var $ = PhiloGL.$;
+
   //Timer based animation
   var Fx = function(options) {
       this.opt = $.merge({

--- a/src/io.js
+++ b/src/io.js
@@ -2,6 +2,7 @@
 //Provides loading of assets with XHR and JSONP methods.
 
 (function () {
+  var $ = PhiloGL.$;
   var IO = {};
 
   var XHR = function(opt) {

--- a/src/io.js
+++ b/src/io.js
@@ -266,8 +266,7 @@
   };
 
   //Load multiple textures from images
-  var Textures = function(opt) {
-    var app = PhiloGL.app;
+  var Textures = function(opt, app) {
     opt = $.merge({
       src: [],
       noCache: false,

--- a/src/io.js
+++ b/src/io.js
@@ -267,6 +267,7 @@
 
   //Load multiple textures from images
   var Textures = function(opt) {
+    var app = PhiloGL.app;
     opt = $.merge({
       src: [],
       noCache: false,

--- a/src/math.js
+++ b/src/math.js
@@ -2,6 +2,7 @@
 //Vec3, Mat4 and Quat classes
 
 (function() {
+
   var sqrt = Math.sqrt, 
       sin = Math.sin,
       cos = Math.cos,

--- a/src/media.js
+++ b/src/media.js
@@ -18,8 +18,8 @@
       position: { x: 0, y: 0, z: 1.205 }
     }), scene = new PhiloGL.Scene({}, camera);
 
-    return function(opt) {
-      var app = PhiloGL.app,
+    return function(opt, app) {
+      var gl = app.gl,
           program = app.program.$$family ? app.program : app.program[opt.program],
           textures = opt.fromTexture ? $.splat(opt.fromTexture) : [],
           framebuffer = opt.toFrameBuffer,
@@ -39,7 +39,6 @@
           scene.add(plane);
       }
 
-      var app = PhiloGL.app;
       if (framebuffer) {
         //create framebuffer
         if (!(framebuffer in app.frameBufferMemo)) {

--- a/src/media.js
+++ b/src/media.js
@@ -2,6 +2,7 @@
 //media has utility functions for image, video and audio manipulation (and
 //maybe others like device, etc).
 (function() {
+  var $ = PhiloGL.$;
   var Media = {};
 
   var Image = function() {};

--- a/src/media.js
+++ b/src/media.js
@@ -19,7 +19,8 @@
     }), scene = new PhiloGL.Scene({}, camera);
 
     return function(opt) {
-      var program = app.program.$$family ? app.program : app.program[opt.program],
+      var app = PhiloGL.app,
+          program = app.program.$$family ? app.program : app.program[opt.program],
           textures = opt.fromTexture ? $.splat(opt.fromTexture) : [],
           framebuffer = opt.toFrameBuffer,
           screen = !!opt.toScreen,
@@ -38,6 +39,7 @@
           scene.add(plane);
       }
 
+      var app = PhiloGL.app;
       if (framebuffer) {
         //create framebuffer
         if (!(framebuffer in app.frameBufferMemo)) {

--- a/src/o3d.js
+++ b/src/o3d.js
@@ -157,12 +157,13 @@
     },
 
     setIndices: function(program) {
+      var glc = PhiloGL.glConstants
       if (!this.$indices) return;
 
       if (this.dynamic) {
         program.setBuffer('indices-' + this.id, {
-          bufferType: gl.ELEMENT_ARRAY_BUFFER,
-          drawType: gl.STATIC_DRAW,
+          bufferType: glc.ELEMENT_ARRAY_BUFFER,
+          drawType: glc.STATIC_DRAW,
           value: this.$indices,
           size: 1
         });
@@ -237,7 +238,8 @@
     },
 
     setTextures: function(program, force) {
-      var app = PhiloGL.app;
+      var app = program.app;
+          glc = PhiloGL.glConstants;
       this.textures = this.textures? $.splat(this.textures) : [];
       var dist = 5;
       for (var i = 0, texs = this.textures, l = texs.length, mtexs = PhiloGL.Scene.MAX_TEXTURES; i < mtexs; i++) {
@@ -245,10 +247,10 @@
           var isCube = app.textureMemo[texs[i]].isCube;
           if (isCube) {
             program.setUniform('hasTextureCube' + (i + 1), true);
-            program.setTexture(texs[i], gl['TEXTURE' + (i + dist)]);
+            program.setTexture(texs[i], glc['TEXTURE' + (i + dist)]);
           } else {
             program.setUniform('hasTexture' + (i + 1), true);
-            program.setTexture(texs[i], gl['TEXTURE' + i]);
+            program.setTexture(texs[i], glc['TEXTURE' + i]);
           }
         } else {
           program.setUniform('hasTextureCube' + (i + 1), false);
@@ -272,7 +274,8 @@
     },
 
     unsetState: function(program) {
-      var attributes = program.attributes;
+      var attributes = program.attributes,
+          gl = program.gl;
 
       //unbind the array and element buffers
       gl.bindBuffer(gl.ARRAY_BUFFER, null);

--- a/src/o3d.js
+++ b/src/o3d.js
@@ -2,6 +2,7 @@
 //Scene Objects
 
 (function () {
+  var $ = PhiloGL.$;
   //Define some locals
   var Vec3 = PhiloGL.Vec3,
       Mat4 = PhiloGL.Mat4,

--- a/src/o3d.js
+++ b/src/o3d.js
@@ -237,6 +237,7 @@
     },
 
     setTextures: function(program, force) {
+      var app = PhiloGL.app;
       this.textures = this.textures? $.splat(this.textures) : [];
       var dist = 5;
       for (var i = 0, texs = this.textures, l = texs.length, mtexs = PhiloGL.Scene.MAX_TEXTURES; i < mtexs; i++) {

--- a/src/program.js
+++ b/src/program.js
@@ -263,6 +263,7 @@
 
   ['setBuffer', 'setBuffers', 'use'].forEach(function(name) {
     Program.prototype[name] = function() {
+      var app = PhiloGL.app;
       var args = Array.prototype.slice.call(arguments);
       args.unshift(this);
       app[name].apply(app, args);
@@ -273,6 +274,7 @@
   ['setFrameBuffer', 'setFrameBuffers', 'setRenderBuffer', 
    'setRenderBuffers', 'setTexture', 'setTextures'].forEach(function(name) {
     Program.prototype[name] = function() {
+      var app = PhiloGL.app;
       app[name].apply(app, arguments);
       return this;
     };

--- a/src/program.js
+++ b/src/program.js
@@ -3,6 +3,7 @@
 //buffers attributes and uniforms
 
 (function() {
+  var $ = PhiloGL.$;
   //First, some privates to handle compiling/linking shaders to programs.
   
   //Creates a shader from a string source.

--- a/src/scene.js
+++ b/src/scene.js
@@ -4,7 +4,8 @@
 (function() {
   //Define some locals
   var Vec3 = PhiloGL.Vec3,
-      Mat4 = PhiloGL.Mat4;
+      Mat4 = PhiloGL.Mat4,
+      $ = PhiloGL.$;
 
   //Scene class
   var Scene = function(program, camera, opt) {

--- a/src/scene.js
+++ b/src/scene.js
@@ -212,6 +212,7 @@
     },
 
     renderToTexture: function(name, opt) {
+      var app = PhiloGL.app;
       opt = opt || {};
       var texture = app.textures[name + '-texture'],
           texMemo = app.textureMemo[name + '-texture'];
@@ -260,6 +261,7 @@
 
     //setup picking framebuffer
     setupPicking: function() {
+      var app = PhiloGL.app;
       //create picking program
       var program = PhiloGL.Program.fromDefaultShaders(),
           floor = Math.floor;
@@ -285,6 +287,7 @@
 
     //returns an element at the given position
     pick: function(x, y, lazy) {
+      var app = PhiloGL.app;
       //setup the picking program if this is
       //the first time we enter the method.
       if (!this.pickingProgram) {

--- a/src/scene.js
+++ b/src/scene.js
@@ -41,6 +41,7 @@
     }, opt || {});
 
     this.program = opt.program ? program[opt.program] : program;
+    this.app = this.program.app;
     this.camera = camera;
     this.models = [];
     this.config = opt;
@@ -212,7 +213,8 @@
     },
 
     renderToTexture: function(name, opt) {
-      var app = PhiloGL.app;
+      var app = this.app,
+          gl = app.gl;
       opt = opt || {};
       var texture = app.textures[name + '-texture'],
           texMemo = app.textureMemo[name + '-texture'];
@@ -232,6 +234,8 @@
           world = view.mulMat4(object),
           worldInverse = world.invert(),
           worldInverseTranspose = worldInverse.transpose();
+          app = program.app,
+          gl = app.gl;
 
       obj.setState(program);
 
@@ -261,9 +265,9 @@
 
     //setup picking framebuffer
     setupPicking: function() {
-      var app = PhiloGL.app;
+      var app = this.app;
       //create picking program
-      var program = PhiloGL.Program.fromDefaultShaders(),
+      var program = PhiloGL.Program.fromDefaultShaders({app: app, gl: app.gl}),
           floor = Math.floor;
       //create framebuffer
       app.setFrameBuffer('$picking', {
@@ -287,7 +291,6 @@
 
     //returns an element at the given position
     pick: function(x, y, lazy) {
-      var app = PhiloGL.app;
       //setup the picking program if this is
       //the first time we enter the method.
       if (!this.pickingProgram) {

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -2,6 +2,7 @@
 //Default Shaders
 
 (function() {
+  var $ = PhiloGL.$;
   //Add default shaders
   var Shaders = {
     Vertex: {},

--- a/src/webgl.js
+++ b/src/webgl.js
@@ -2,6 +2,7 @@
 //Checks if WebGL is enabled and creates a context for using WebGL.
 
 (function () {
+  var $ = PhiloGL.$;
 
   var WebGL = {
 

--- a/src/webgl.js
+++ b/src/webgl.js
@@ -79,6 +79,7 @@
     $$family: 'application',
 
     setBuffer: function(program, name, opt) {
+      var gl = this.gl;
       //unbind buffer
       if (opt === false || opt === null) {
         opt = this.bufferMemo[name];
@@ -158,6 +159,7 @@
     },
 
     setFrameBuffer: function(name, opt) {
+      var gl = this.gl;
       //bind/unbind framebuffer
       if (typeof opt != 'object') {
         gl.bindFramebuffer(gl.FRAMEBUFFER, opt? this.frameBuffers[name] : null);
@@ -235,6 +237,7 @@
     },
 
     setRenderBuffer: function(name, opt) {
+      var gl = this.gl;
       if (typeof opt != 'object') {
         gl.bindRenderbuffer(gl.RENDERBUFFER, opt? this.renderBufferMemo[name] : null);
         return;
@@ -270,6 +273,7 @@
     },
 
     setTexture: function(name, opt) {
+      var gl = this.gl;
       //bind texture
       if (!opt || typeof opt != 'object') {
         gl.activeTexture(opt || gl.TEXTURE0);
@@ -401,6 +405,7 @@
     },
 
     use: function(program) {
+      var gl = this.gl;
       gl.useProgram(program.program);
       //remember last used program.
       this.usedProgram = program;


### PR DESCRIPTION
GL Contexts: Previously PhiloGL was only able to support a single GL context at a time. Thanks to some refactoring that is no longer the case. Commit 818b319 adds multiple context support so now we can create as many webGL canvases as we want with PhiloGL.

Scoping: The $ was previously polluting the global name space when I included the individual src files of PhiloGL directly so I scoped it to PhiloGL.$ and aliased $ to it inside each closure. Also the app and globalContext variables were removed from the top level global namespace. PhiloGL should now be the only addition to the top level global namespace.
