### PR TITLE
fix PhiloGL.Program.fromShaderIds

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -298,7 +298,7 @@
       fs = $(opt.fs);
     return preprocess(opt.path, vs.innerHTML, function(vectexShader) {
       return preprocess(opt.path, fs.innerHTML, function(fragmentShader) {
-        opt.onSuccess(new Program(vectexShader, fragmentShader), opt);
+        return new Program(vectexShader, fragmentShader);
       });
     });
   };


### PR DESCRIPTION
Commit d8a63a412826fa409db78e2f5b3620e09ac1074c introduced a bug which
broke fromShaderIds.  This is specifically here:
https://github.com/senchalabs/philogl/commit/d8a63a412826fa409db78e2f5b3620e09ac1074c#diff-9589e3a0cc72e26a4814bc9ef05aa2d4R301

fromShaderIds is supposed to return a Program, but instead this function is
delegating to onSuccess.  But the arguments/options never allow an onSuccess
to be specified.

This patch removes that onSuccess call and just returns the Program.
